### PR TITLE
Adding the ability to ignore test failures so CI systems such as Bamb…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can also specify other cucumber related configurations, a list of them is be
 | threadCount | ```int``` | Number of process to start | Number of available CPU cores on the system |
 | enhancedJsonReporting| ```boolean``` | When set to true, reports are generated after each scenario and saved to disk and reports are updated| false |
 | jvmArgs | ```String``` | JVM arguments that will be passed to cucumber process | empty string |
+| testFailureIgnore | ```boolean``` | When set to true, test failures are ignored when determining if the build succeeded. Use ```cucumberRunner.test.failure.ignore``` to pass it in as a system property at runtime. | false |
 
 # Requirements
 Maven 3, Java 8

--- a/src/main/java/eu/evops/maven/plugins/cucumber/parallel/Run.java
+++ b/src/main/java/eu/evops/maven/plugins/cucumber/parallel/Run.java
@@ -19,12 +19,7 @@ import org.codehaus.plexus.util.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import static java.lang.String.format;
 
@@ -141,6 +136,13 @@ public class Run extends AbstractMojo {
     @Parameter(property = "cucumberRunner.combineReports")
     boolean combineReports;
 
+    /**
+     * Controls failing the build if their are test failures. Needed for CI systems such
+     * as Bamboo that allow quarantining of failing tests.
+     */
+    @Parameter(property = "cucumberRunner.test.failure.ignore")
+    boolean testFailureIgnore;
+
     private File threadFolder;
     private String streamingFormatterClassName = StreamingJSONFormatter.class.getName();
 
@@ -235,7 +237,7 @@ public class Run extends AbstractMojo {
                 report();
             }
 
-            if(!haveAllThreadsPassed(threads)) {
+            if(!testFailureIgnore && !haveAllThreadsPassed(threads)) {
                 throw new MojoFailureException(format("Some of the threads have failed, please inspect output folder: %s", getThreadFolder().getAbsolutePath()));
             }
         }

--- a/src/main/java/eu/evops/maven/plugins/cucumber/parallel/Run.java
+++ b/src/main/java/eu/evops/maven/plugins/cucumber/parallel/Run.java
@@ -19,7 +19,12 @@ import org.codehaus.plexus.util.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
 
 import static java.lang.String.format;
 

--- a/src/test/java/MojoTest.java
+++ b/src/test/java/MojoTest.java
@@ -101,7 +101,7 @@ public class MojoTest {
     }
 
     @Test
-    public void testThatTestFailuresAreNotIgnoredWhenTestFailureIgnoreIsFalse() throws IOException, InterruptedException {
+    public void testThatTestFailuresAreNotIgnoredWhenTestFailureIgnoreIsFalseUsingJVMArgs() throws IOException, InterruptedException {
         ProcessBuilder processBuilder = new ProcessBuilder();
         processBuilder.directory(testProjectToIgnoreTestFailures);
         processBuilder.command("mvn", "clean", "integration-test", "-DcucumberRunner.test.failure.ignore=false");
@@ -120,7 +120,7 @@ public class MojoTest {
     }
 
     @Test
-    public void testThatTestFailuresAreIgnoredWhenTestFailureIgnoreIsTrue() throws IOException, InterruptedException {
+    public void testThatTestFailuresAreIgnoredWhenTestFailureIgnoreIsTrueUsingJVMArgs() throws IOException, InterruptedException {
         ProcessBuilder processBuilder = new ProcessBuilder();
         processBuilder.directory(testProjectToIgnoreTestFailures);
         processBuilder.command("mvn", "clean", "integration-test", "-DcucumberRunner.test.failure.ignore=true");
@@ -135,6 +135,43 @@ public class MojoTest {
         }
 
         System.out.println(lines);
+
+        assertTrue(lines.contains("BUILD SUCCESS"));
+    }
+
+    @Test
+    public void testThatTestFailuresAreNotIgnoredByDefault() throws IOException, InterruptedException {
+        ProcessBuilder processBuilder = new ProcessBuilder();
+        processBuilder.directory(testProjectToIgnoreTestFailures);
+        processBuilder.command("mvn", "clean", "integration-test");
+
+        Process start = processBuilder.start();
+        start.waitFor();
+
+        String lines;
+
+        try ( BufferedReader reader = new BufferedReader(new InputStreamReader(start.getInputStream())) ) {
+            lines = String.join(System.lineSeparator(), reader.lines().collect(toList()));
+        }
+
+        assertTrue(lines.contains("BUILD FAILURE"));
+        assertTrue(lines.contains("Some of the threads have failed, please inspect output folder:"));
+    }
+
+    @Test
+    public void testThatTestFailuresAreIgnoredWhenTestFailureIgnoreIsTrue() throws IOException, InterruptedException {
+        ProcessBuilder processBuilder = new ProcessBuilder();
+        processBuilder.directory(testProjectToIgnoreTestFailures);
+        processBuilder.command("mvn", "clean", "integration-test", "-Pignore-test-failures");
+
+        Process start = processBuilder.start();
+        start.waitFor();
+
+        String lines;
+
+        try ( BufferedReader reader = new BufferedReader(new InputStreamReader(start.getInputStream())) ) {
+            lines = String.join(System.lineSeparator(), reader.lines().collect(toList()));
+        }
 
         assertTrue(lines.contains("BUILD SUCCESS"));
     }

--- a/test-project-testFailureIgnore/pom.xml
+++ b/test-project-testFailureIgnore/pom.xml
@@ -36,6 +36,24 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>ignore-test-failures</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>eu.evops.maven.plugins</groupId>
+                        <artifactId>cucumber-runner-maven-plugin</artifactId>
+                        <version>1.16-SNAPSHOT</version>
+                        <configuration>
+                            <testFailureIgnore>true</testFailureIgnore>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>info.cukes</groupId>

--- a/test-project-testFailureIgnore/pom.xml
+++ b/test-project-testFailureIgnore/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>pom-test</groupId>
+    <artifactId>pom-test-group</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>eu.evops.maven.plugins</groupId>
+                <artifactId>cucumber-runner-maven-plugin</artifactId>
+                <version>1.16-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>integration</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <combineReports>true</combineReports>
+                    <features>
+                        <feature>src/test/resources</feature>
+                    </features>
+                    <gluePaths>
+                        <gluePath>steps</gluePath>
+                    </gluePaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>1.2.5</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/test-project-testFailureIgnore/src/test/java/steps/TestSteps.java
+++ b/test-project-testFailureIgnore/src/test/java/steps/TestSteps.java
@@ -1,0 +1,12 @@
+package steps;
+
+import cucumber.api.java.en.Given;
+import org.junit.Assert;
+
+public class TestSteps {
+
+    @Given("^I have a failing step$")
+    public void iHaveAFailingStep() throws Throwable {
+        Assert.assertTrue(false);
+    }
+}

--- a/test-project-testFailureIgnore/src/test/resources/test.feature
+++ b/test-project-testFailureIgnore/src/test/resources/test.feature
@@ -1,0 +1,4 @@
+Feature: testFailureIgnore Flag
+
+  Scenario: Scenario 1
+    Given I have a failing step


### PR DESCRIPTION
…oo can process the test  themselves.

* Defaults to not ignore test failures
* Set the property cucumberRunner.test.failure.ignore on the command line
* Set the property <testFailureIgnore> in plugin configuration

Fix for Issue #7 